### PR TITLE
Update ci.yaml with ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,25 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  ci:
-    name: CI Pipeline
+  lint:
+    name: Lint
+    runs-on: macos-15
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    
+    - name: Install just
+      run: brew install just
+    
+    - name: Install SwiftLint
+      run: brew install swiftlint
+    
+    - name: Run Lint
+      run: just lint
+
+  build:
+    name: Build
     runs-on: macos-15
     
     steps:
@@ -22,9 +39,6 @@ jobs:
     
     - name: Install just
       run: brew install just
-    
-    - name: Install SwiftLint
-      run: brew install swiftlint
     
     - name: Cache Swift Package Manager
       uses: actions/cache@v4
@@ -42,14 +56,75 @@ jobs:
     - name: Resolve Swift Package Dependencies
       run: swift package resolve
     
-    - name: Lint
-      run: just lint
-    
-    - name: Build
+    - name: Run Build
       run: just build
+
+  build-ios:
+    name: Build iOS
+    runs-on: macos-15
     
-    - name: Build iOS
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.4'
+    
+    - name: Install just
+      run: brew install just
+    
+    - name: Cache Swift Package Manager
+      uses: actions/cache@v4
+      with:
+        path: |
+          .build
+          ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+    
+    - name: Configure macro package trust
+      run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+    
+    - name: Resolve Swift Package Dependencies
+      run: swift package resolve
+    
+    - name: Run Build iOS
       run: just build-ios
+
+  test:
+    name: Test
+    runs-on: macos-15
     
-    - name: Test
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.4'
+    
+    - name: Install just
+      run: brew install just
+    
+    - name: Cache Swift Package Manager
+      uses: actions/cache@v4
+      with:
+        path: |
+          .build
+          ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+    
+    - name: Configure macro package trust
+      run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+    
+    - name: Resolve Swift Package Dependencies
+      run: swift package resolve
+    
+    - name: Run Tests
       run: just test


### PR DESCRIPTION
Consolidate CI jobs and update workflow to use `just` commands for linting, building (macOS/iOS), and testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c90e86e-8674-4f0f-b409-9576a7d7b19f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c90e86e-8674-4f0f-b409-9576a7d7b19f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

