### PR TITLE
Remove unused settings from SettingsView

### DIFF
--- a/Packages/OpenCoderCore/Sources/Features/SettingsFeature.swift
+++ b/Packages/OpenCoderCore/Sources/Features/SettingsFeature.swift
@@ -6,9 +6,6 @@ import Models
 public struct SettingsFeature: Sendable {
   @ObservableState
   public struct State: Equatable, Sendable {
-    public var theme: Theme = .system
-    public var notificationsEnabled = true
-    public var autoSaveEnabled = true
     public var thinkingBlocksEnabled = true
     public var showingLogs = false
     public var showingPreviousLogs = false
@@ -78,10 +75,4 @@ public struct SettingsFeature: Sendable {
       return .none
     }
   }
-}
-
-public enum Theme: String, Equatable, CaseIterable, Sendable {
-  case light
-  case dark
-  case system
 }

--- a/Packages/OpenCoderUI/Sources/Views/SettingsView.swift
+++ b/Packages/OpenCoderUI/Sources/Views/SettingsView.swift
@@ -13,20 +13,7 @@ struct SettingsView: View {
 
   var body: some View {
     Form {
-      Section(header: Text("Appearance")) {
-        Picker("Theme", selection: $store.theme) {
-          ForEach(Theme.allCases, id: \.self) { theme in
-            Text(theme.rawValue.capitalized)
-          }
-        }
-      }
-
-      Section(header: Text("Notifications")) {
-        Toggle("Enable Notifications", isOn: $store.notificationsEnabled)
-      }
-
       Section(header: Text("General")) {
-        Toggle("Auto Save", isOn: $store.autoSaveEnabled)
         Toggle("Show Thinking Blocks", isOn: $store.thinkingBlocksEnabled)
         Button("Reset to Defaults") {
           store.send(.resetToDefaults)


### PR DESCRIPTION
Removed the following unused settings that were not referenced in the app:
- theme (Appearance section)
- notificationsEnabled (Notifications section)
- autoSaveEnabled (General section)

The thinkingBlocksEnabled setting is kept as it's actively used throughout the chat rendering logic to control the visibility of reasoning blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)